### PR TITLE
Adding config dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq (, $(shell which golint))
 	$(GO) go get -u golang.org/x/lint/golint
 endif
 ifeq (, $(shell which gometalinter))
-        $(GO) go get -u github.com/alecthomas/gometalinter
+	$(GO) go get -u github.com/alecthomas/gometalinter
 endif
 endif
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ For an EVE device to be accepted into Adam, it needs to be listed as one of:
 * acceptable to onboard
 * registered
 
+An EVE device has to know the following before it can communicate with any controller (including Adam):
+
+* controller's host name and port #
+* controller's root certificate
+
+additionally you may need to supply an entry mapping controller's host name to a routable IP address (in the /etc/hosts format)
+
+When Adam server runs, it outputs all the required configuration in a folder specified by the `conf-dir` option (run/adam/config by default)
+
 ### Onboarding
 
 Onboarding is the process of enabling a device to self-register. This requires two pieces: an onboarding certificate, and a unique serial string. Each self-registering device _must_ have a unique combination of onboarding certificate and serial string.

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -8,7 +8,7 @@ const (
 	serverCertFilename = "server.pem"
 	serverKeyFilename  = "server-key.pem"
 	defaultDatabaseURL = "./run/adam"
-	configDir          = "./run/adam/config"
+	defaultConfigDir   = "./run/adam/config"
 	jsonContentType    = "application/json"
 	textContentType    = "text/plain"
 )
@@ -20,6 +20,7 @@ var (
 	hosts       string
 	force       bool
 	databaseURL string
+	configDir   string
 )
 
 func getFriendlyCN(cn string) string {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -8,6 +8,7 @@ const (
 	serverCertFilename = "server.pem"
 	serverKeyFilename  = "server-key.pem"
 	defaultDatabaseURL = "./run/adam"
+	configDir          = "./run/adam/config"
 	jsonContentType    = "application/json"
 	textContentType    = "text/plain"
 )

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -96,5 +96,6 @@ func serverInit() {
 	serverCmd.Flags().StringVar(&serverCert, "server-cert", path.Join(defaultDatabaseURL, serverCertFilename), "path to server certificate")
 	serverCmd.Flags().StringVar(&serverKey, "server-key", path.Join(defaultDatabaseURL, serverKeyFilename), "path to server key")
 	serverCmd.Flags().StringVar(&databaseURL, "db-url", defaultDatabaseURL, "path to directory where we will store and find device information, including onboarding certificates, device certificates, config, logs and metrics. See the readme for more details.")
+	serverCmd.Flags().StringVar(&configDir, "conf-dir", defaultConfigDir, "path to directory where running server will output runtime configuration files that can be fed into EVE")
 	serverCmd.Flags().IntVar(&certRefresh, "cert-refresh", defaultCertRefresh, "how often, in seconds, to refresh the onboarding and device certs from the filesystem; 0 means not to cache at all.")
 }


### PR DESCRIPTION
Making adam write out some of its runtime configuration into the filesystem so that EVE can pick it up and use during boostrap sequence.