### PR TITLE
Config dir fmt

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -8,7 +8,7 @@ const (
 	serverCertFilename = "server.pem"
 	serverKeyFilename  = "server-key.pem"
 	defaultDatabaseURL = "./run/adam"
-	defaultConfigDir   = "./run/adam/config"
+	defaultConfigDir   = "./run/config"
 	jsonContentType    = "application/json"
 	textContentType    = "text/plain"
 )

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -76,6 +76,7 @@ var serverCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("error writing hosts file: %v", err)
 		}
+		log.Printf("EVE-compatible configuration directory output to %s", configDir)
 
 		s := &server.Server{
 			Port:          port,

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -67,16 +67,15 @@ var serverCmd = &cobra.Command{
 			log.Fatalf("error parsing server cert: %v", err)
 		}
 
-		err = ioutil.WriteFile(path.Join(configDir, "server"), []byte(ca.Subject.CommonName + ":" + port), 0644)
+		err = ioutil.WriteFile(path.Join(configDir, "server"), []byte(ca.Subject.CommonName+":"+port), 0644)
 		if err != nil {
 			log.Fatalf("error writing to server file: %v", err)
 		}
 
-		err = ioutil.WriteFile(path.Join(configDir, "hosts"), []byte(hostIP + " " + ca.Subject.CommonName), 0644)
+		err = ioutil.WriteFile(path.Join(configDir, "hosts"), []byte(hostIP+" "+ca.Subject.CommonName), 0644)
 		if err != nil {
 			log.Fatalf("error writing hosts file: %v", err)
 		}
-
 
 		s := &server.Server{
 			Port:          port,


### PR DESCRIPTION
Resolves the small outstanding issues from #3:

* changes default config output dir from `run/adam/config/` (inside the device database which will not exist if the backing store is not file, and could be elsewhere anyways) to `run/config/`, which always can exist and is outside the database
* reports where it output the config on startup
* correctly formats one of the go files